### PR TITLE
Add `reportConnected`, so clients can update the connectivity status when they have requests succeed.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,18 @@ export function fetch(
 }
 
 /**
+ * Update the connectivity status, postponing the automatic connectivity check
+ * (if applicable). Use this to cut down on extraneous network traffick, if you
+ * are already making requests that indicate connectivity.
+ */
+export function reportConnected(): void {
+  if (!_state) {
+    _state = createState();
+  }
+  _state.reportConnected();
+}
+
+/**
  * Subscribe to connection information. The callback is called with a parameter of type
  * [`NetInfoState`](README.md#netinfostate) whenever the connection state changes. Your listener
  * will be called with the latest information soon after you subscribe and then with any

--- a/src/internal/internetReachability.ts
+++ b/src/internal/internetReachability.ts
@@ -142,6 +142,26 @@ export default class InternetReachability {
     };
   };
 
+  public reportConnected = (): void => {
+    // Cancel any pending check
+    if (this._currentInternetReachabilityCheckHandler !== null) {
+      this._currentInternetReachabilityCheckHandler.cancel();
+      this._currentInternetReachabilityCheckHandler = null;
+    }
+    // Cancel any pending timeout
+    if (this._currentTimeoutHandle !== null) {
+      clearTimeout(this._currentTimeoutHandle);
+      this._currentTimeoutHandle = null;
+    }
+
+    this._setIsInternetReachable(true);
+
+    this._currentTimeoutHandle = setTimeout(
+      this._checkInternetReachability,
+      this._configuration.reachabilityLongTimeout,
+    );
+  };
+
   public update = (state: PrivateTypes.NetInfoNativeModuleState): void => {
     if (typeof state.isInternetReachable === 'boolean') {
       this._setIsInternetReachable(state.isInternetReachable);

--- a/src/internal/state.ts
+++ b/src/internal/state.ts
@@ -94,6 +94,10 @@ export default class State {
     }
   };
 
+  public reportConnected(): void {
+    this._internetReachability.reportConnected();
+  }
+
   public latest = (
     requestedInterface?: string,
   ): Promise<Types.NetInfoState> => {


### PR DESCRIPTION
## Summary:
As a way to cut down on unneeded network calls, the client app can inform react-native-netinfo that a request has succeeded, and that it can therefore reset its current reachability timeout.

## Test plan:
:fingers-crossed:
there aren't currently any tests that involve the reachability timeout, and I don't super want to mess with timeouts in tests 🙃